### PR TITLE
Repair consistent 2 minute refresh and loading spinner and video bar usablility

### DIFF
--- a/src/js/ClspHandler.js
+++ b/src/js/ClspHandler.js
@@ -93,6 +93,8 @@ export default class ClspHandler extends Component {
     const collection = IovCollection.asSingleton();
     const iov = await collection.create(videoId, this.source_.src);
 
+    // It is unclear why "this.player.on('ready', () => {})" is not working;
+    // however, "this.player.ready()" has worked consistently without any issue
     this.player.ready(() => {
       if (this.onReadyAlreadyCalled) {
         this.logger.warn('tried to use this player more than once...');

--- a/src/js/ClspHandler.js
+++ b/src/js/ClspHandler.js
@@ -90,9 +90,10 @@ export default class ClspHandler extends Component {
 
     videoElementParent.insertBefore(videoElement, videoJsVideoElement);
 
-    const iov = await IovCollection.asSingleton().create(videoId, this.source_.src);
+    const collection = IovCollection.asSingleton();
+    const iov = await collection.create(videoId, this.source_.src);
 
-    this.player.on('ready', () => {
+    this.player.ready(() => {
       if (this.onReadyAlreadyCalled) {
         this.logger.warn('tried to use this player more than once...');
         return;
@@ -101,12 +102,6 @@ export default class ClspHandler extends Component {
       this.onReadyAlreadyCalled = true;
 
       const videoTag = this.player.children()[0];
-
-      // @todo - there must be a better way to determine autoplay...
-      if (videoTag.getAttribute('autoplay') !== null) {
-        // playButton.trigger('click');
-        this.player.trigger('play', videoTag);
-      }
 
       iov.on('firstFrameShown', () => {
         this.player.trigger('firstFrameShown');

--- a/src/styles/videojs.scss
+++ b/src/styles/videojs.scss
@@ -1,2 +1,6 @@
 @import 'node_modules/video.js/src/css/video-js.scss';
 // @import 'node_modules/video.js/dist/video-js.css';
+
+.vjs-loading-spinner,.vjs-control-bar {
+    z-index: 2;
+}


### PR DESCRIPTION
- Remove redundant "autoplay" play trigger when the player is ready
- Correctly run CslpHandler code when the player is ready
   - In particular enable the stream's "heartbeat" to start and continue
- Repair loading spinner icon and video bar z-index to be visible on the video element